### PR TITLE
Re-add coID type specification

### DIFF
--- a/2.4.0/common/dataformats.md
+++ b/2.4.0/common/dataformats.md
@@ -189,7 +189,14 @@ Examples
 
 References
  * [RFC 5952](https://tools.ietf.org/html/rfc5952)
- 
+
+### coID
+Identification of the communication operator.
+
+* May only concist of a-z, A-Z, 0-9, '-' and '.'
+* Matching regular expression [a-zA-Z0-9-.]+
+* Max length 32 characters
+
 ### dateTime
 Date and time according to ISO-8601 RFC-3339 in UTC time zone with up to 4 decimal places on seconds.
 

--- a/2.4.0/spec/web_portal.md
+++ b/2.4.0/spec/web_portal.md
@@ -31,7 +31,7 @@ Host name and path are set by the service provider and are used by the communica
 		</td>
 		<td>
 			<p>Identification of the communication operator.</p>
-			<p>See coID in <a href="dataformats.md">dataformats</a></p>
+			<p>See coID in <a href="="../common/dataformats.md#coid">dataformats</a></p>
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
The coID type specification seems to have been lost in commit a8a34f6d899eb.

It is linked from spec/web_portal.md.