### PR TITLE
Request-information-with-a-ticket-reference

### DIFF
--- a/2.4.0/spec/contacts.md
+++ b/2.4.0/spec/contacts.md
@@ -20,7 +20,7 @@ POST /2.4/contacts/{ spReference }
 
 Request information with a ticket reference:
 ```http
-POST /2.4/contacts/{ spReference }
+POST /2.4/contacts/{ spTicketReference }
 
 {
   "spTicketReference": "123"


### PR DESCRIPTION
Changed so that it says POST /2.4/contacts/{ spTicketReference } instead of POST /2.4/contacts/{ spReference } in the second example ("Request information with a ticket reference").