### PR TITLE
Remove bloated text in readme

### DIFF
--- a/2.5.0/README.md
+++ b/2.5.0/README.md
@@ -15,7 +15,7 @@
 * [Option82 lookup](spec/option82_lookup.md)
 * [Order events](spec/orderevents.md)
 * [Orders](spec/orders.md)
-* [Subscriptions - list active services](spec/subscriptions.md)
+* [Subscriptions](spec/subscriptions.md)
 * [Technical information](spec/technical_info.md)
 * [Tickets](spec/tickets.md)
 


### PR DESCRIPTION
A bit strange to only describing the purpose of the subscriptions endpoint.