### PR TITLE
Removed "type" from the operation CHANGE

### DIFF
--- a/2.5.0/spec/orders.md
+++ b/2.5.0/spec/orders.md
@@ -550,7 +550,7 @@ The type of operation this order is intended to perform.
     * Update a service with new parameters
 * CHANGE
     * Requires subscriptionId
-    * Change the current service type to a new service type
+    * Change the current service to a new service
 
 ### requestedDateTime
 


### PR DESCRIPTION
Removed "type" from the operation CHANGE. Should be service instead of service type.