### PR TITLE
Fix examples and formating

### DIFF
--- a/2.4.0/spec/accesses.md
+++ b/2.4.0/spec/accesses.md
@@ -123,7 +123,7 @@ When all accesses or updates are requested the response contains a JSON-array wi
 
 #### Single access
 
-To get a single access use accessId as key. The single access contains details about activated services and the services
+To get a single access use `accessId` as key. The single access contains details about activated services and the services
  available for activation.
  
 Request

--- a/2.4.0/spec/accesses.md
+++ b/2.4.0/spec/accesses.md
@@ -11,7 +11,7 @@ access resides, available services, equipment and activated services.
 
 #### All accesses 
 ```HTTP
-accesses/ HTTP/1.1
+GET /onapi/2.4/accesses/ HTTP/1.1
 ```
 
 Response 
@@ -35,7 +35,7 @@ header from the previous response.
 
 Request
 ```HTTP
-accesses/ HTTP/1.1
+GET /onapi/2.4/accesses/ HTTP/1.1
 If-Modified-Since: Mon, 04 Feb 2019 18:12:33 GMT
 ```
 

--- a/2.4.0/spec/contacts.md
+++ b/2.4.0/spec/contacts.md
@@ -7,7 +7,7 @@ _**Note:**_  This API is hosted by the service provider, and the communication o
 
 ## Specification
 The fields `reason` and `spTicketReference` is used to able to track requests of personal information.
-Providing spTicketReference makes `reason` unnecessary.
+Providing `spTicketReference` makes `reason` unnecessary.
 
 Request information with a reason:
 ```http

--- a/2.4.0/spec/events.md
+++ b/2.4.0/spec/events.md
@@ -14,7 +14,7 @@ Events for the current second is omitted to ensure that events are not sent twic
 in the "If-Modified-Since" header that does not allow fractional seconds. 
 
 ```HTTP
-/onapi/2.4/events/ HTTP/1.1
+GET /onapi/2.4/events/ HTTP/1.1
 ```
 
 Response 
@@ -49,7 +49,7 @@ needs to be fairly lightweight on the API-server side to allow rapid requests.
 
 Request
 ```HTTP
-/onapi/2.4/events/ HTTP/1.1
+GET /onapi/2.4/events/ HTTP/1.1
 If-Modified-Since: Tue, 05 Feb 2019 13:03:15 GMT
 ```
 

--- a/2.4.0/spec/invoice_specification.md
+++ b/2.4.0/spec/invoice_specification.md
@@ -44,7 +44,9 @@ Content-Type: application/json
 ]
 ```
 
-A GET operation with a id from the previous list operation as key fetches the specification that invoice.
+#### Single invoice
+
+A GET operation with an `id` from the previous list operation as key fetches the specification for that invoice.
 
 ```HTTP
 GET /onapi/2.4/invoicespecification/201901 HTTP/1.1

--- a/2.4.0/spec/orders.md
+++ b/2.4.0/spec/orders.md
@@ -407,26 +407,6 @@ Location: /onapi/2.4/orders/f3f26446f6e8407aae876ea8e52d7417
 Content-Type: application/json
 ```
 
-#### Modify a service
-Request
-```HTTP
-POST /onapi/2.4/orders/ HTTP/1.1
-Content-Type: application/json
-```
-```JSON
-{
-  "subscriptionId": "35738e19ab534dff9f9becb3a064a7d5",
-  "operation": "MODIFY",
-  "spReference": "a6cc5da980034948ba654ae6ceda03f4",
-  "spSubscriptionId": "d02925f0083b4f64993b365accfbb1ac"
-}
-```
-Response
-```HTTP
-HTTP/1.1 201 CREATED
-Location: /onapi/2.4/orders/f3f26446f6e8407aae876ea8e52d7417
-Content-Type: application/json
-```
 ```JSON
 {
   "path": "/onapi/2.4/orders/f3f26446f6e8407aae876ea8e52d7417",

--- a/2.4.0/spec/orders.md
+++ b/2.4.0/spec/orders.md
@@ -456,6 +456,12 @@ Content-Type: application/json
 }
 ```
 
+Response
+
+```HTTP
+HTTP/1.1 204 No Content
+```
+
 ### PATCH
 
 With patch it is possible to update an order for which the state is "RECEIVED", using only the changed part.

--- a/2.4.0/spec/orders.md
+++ b/2.4.0/spec/orders.md
@@ -158,6 +158,8 @@ Content-Type: application/json
 
 #### Get a single order
 
+Use `orderId` as key.
+
 Request
 
 ```HTTP
@@ -418,6 +420,7 @@ Content-Type: application/json
 ### PUT
 
 With put it is possible to update an order for which the state is "RECEIVED", using the complete object.
+Use `orderId` as key.
 
 Request
 
@@ -456,6 +459,7 @@ Content-Type: application/json
 ### PATCH
 
 With patch it is possible to update an order for which the state is "RECEIVED", using only the changed part.
+Use `orderId` as key.
 
 Request
 
@@ -477,7 +481,9 @@ HTTP/1.1 204 No Content
 ```
 
 ### DELETE
-Used to cancel an order for which the state is "RECEIVED". Example: could be used to cancel a previous order with operation DEACTIVATE, if the end customer no longer wants to cancel his or hers subscription.
+Used to cancel an order for which the state is "RECEIVED". Use `orderId` as key.
+Example: could be used to cancel a previous order with operation DEACTIVATE, if the end customer no longer wants to
+cancel his or hers subscription.
 
 Request
 

--- a/2.5.0/spec/accesses.md
+++ b/2.5.0/spec/accesses.md
@@ -123,7 +123,7 @@ When all accesses or updates are requested the response contains a JSON-array wi
 
 #### Single access
 
-To get a single access use accessId as key. The single access contains details about activated services and the services
+To get a single access use `accessId` as key. The single access contains details about activated services and the services
  available for activation.
  
 Request

--- a/2.5.0/spec/accesses.md
+++ b/2.5.0/spec/accesses.md
@@ -11,7 +11,7 @@ access resides, available services, equipment and activated services.
 
 #### All accesses 
 ```HTTP
-accesses/ HTTP/1.1
+GET /onapi/2.5/accesses/ HTTP/1.1
 ```
 
 Response 
@@ -35,7 +35,7 @@ header from the previous response.
 
 Request
 ```HTTP
-accesses/ HTTP/1.1
+GET /onapi/2.5/accesses/ HTTP/1.1
 If-Modified-Since: Mon, 04 Feb 2019 18:12:33 GMT
 ```
 

--- a/2.5.0/spec/events.md
+++ b/2.5.0/spec/events.md
@@ -14,7 +14,7 @@ Events for the current second is omitted to ensure that events are not sent twic
 in the "If-Modified-Since" header that does not allow fractional seconds. 
 
 ```HTTP
-/onapi/2.5/events/ HTTP/1.1
+GET /onapi/2.5/events/ HTTP/1.1
 ```
 
 Response 
@@ -49,7 +49,7 @@ needs to be fairly lightweight on the API-server side to allow rapid requests.
 
 Request
 ```HTTP
-/onapi/2.5/events/ HTTP/1.1
+GET /onapi/2.5/events/ HTTP/1.1
 If-Modified-Since: Tue, 05 Feb 2019 13:03:15 GMT
 ```
 

--- a/2.5.0/spec/invoice_specification.md
+++ b/2.5.0/spec/invoice_specification.md
@@ -44,7 +44,9 @@ Content-Type: application/json
 ]
 ```
 
-A GET operation with a id from the previous list operation as key fetches the specification that invoice.
+#### Single invoice
+
+A GET operation with an `id` from the previous list operation as key fetches the specification for that invoice.
 
 ```HTTP
 GET /onapi/2.5/invoicespecification/201901 HTTP/1.1

--- a/2.5.0/spec/orders.md
+++ b/2.5.0/spec/orders.md
@@ -161,6 +161,8 @@ Content-Type: application/json
 
 #### Get a single order
 
+Use `orderId` as key.
+
 Request
 
 ```HTTP
@@ -430,7 +432,7 @@ Content-Type: application/json
 
 #### Modify a subscription
 
-Used to modify spReference and/or spSubscriptionId.
+Used to modify `spReference` and/or `spSubscriptionId`.
 
 Request
 
@@ -471,6 +473,7 @@ Content-Type: application/json
 ### PUT
 
 With put it is possible to update an order for which the state is "RECEIVED", using the complete object.
+Use `orderId` as key.
 
 Request
 
@@ -517,6 +520,7 @@ HTTP/1.1 204 No Content
 ### PATCH
 
 With patch it is possible to update an order for which the state is "RECEIVED", using only the changed part.
+Use `orderId` as key.
 
 Request
 
@@ -539,7 +543,7 @@ HTTP/1.1 204 No Content
 
 ### DELETE
 
-Used to cancel an order for which the state is "RECEIVED".
+Used to cancel an order for which the state is "RECEIVED". Use `orderId` as key.
 
 Request
 
@@ -692,4 +696,3 @@ Can be used in the response to describe why the status is DONE_FAILED
 
 * Data format: [text](../common/dataformats.md#text)
 * Required (but may be empty)
- 

--- a/2.5.0/spec_sp/coorder.md
+++ b/2.5.0/spec_sp/coorder.md
@@ -32,7 +32,7 @@ end
 ## Request
 
 ```http
-POST coorder/ HTTP/1.1
+POST /onapi/2.5/coorder/ HTTP/1.1
 Content-Type: application/json
 ```
 

--- a/2.5.0/spec_sp/order.md
+++ b/2.5.0/spec_sp/order.md
@@ -35,7 +35,7 @@ end
 ## Request
 
 ```http
-POST order/ HTTP/1.1
+POST /onapi/2.5/order/ HTTP/1.1
 Content-Type: application/json
 ```
 

--- a/2.5.0/spec_sp/ordernotice.md
+++ b/2.5.0/spec_sp/ordernotice.md
@@ -19,7 +19,7 @@ respond back with subscription and customer references.
 ## Request
 
 ```http
-POST activationnotice/ HTTP/1.1
+POST /onapi/2.5/activationnotice/ HTTP/1.1
 Content-Type: application/json
 ```
 

--- a/2.5.0/spec_sp/products.md
+++ b/2.5.0/spec_sp/products.md
@@ -26,7 +26,7 @@ offeringId, the CO must provide the combination of both when placing orders.
 The request below is used to list all products and offerings made available by the SP in the CO network
 
 ```http
-GET products/
+GET /onapi/2.5/products/
 Content-Type: application/json
 ```
 
@@ -34,7 +34,7 @@ Add the "accessId" from the CO accesses API to list offerings available on the s
 The list shall only contain the offerings that the SP wants to deliver to the specific accessId. 
 
 ```http
-GET products/[accessId]
+GET /onapi/2.5/products/{accessId}
 Content-Type: application/json
 ```
 
@@ -47,7 +47,7 @@ available on the specific access.
 The "coProduct" is the same field as services/service specified in the CO endpoint [accesses API](../spec/accesses.md)
 
 ```http 
-POST products/[accessId]
+POST /onapi/2.5/products/{accessId}
 Content-Type: application/json
 ```
 


### PR DESCRIPTION
This includes a bunch of little fixes

* De-duplicate a section that was printed twice ("Modify a service" in 2.4 accesses)
* Requests should be prefixed by `{method} /onapi/{version}/` in examples
* Added a missing response in PUT /onapi/2.4/accesses 
* Added info about what key should be used in URLs

closes #74 