### PR TITLE
Update URLs in 2.4 and 2.5 to use key within {} for ids

### DIFF
--- a/2.4.0/spec/accesses.md
+++ b/2.4.0/spec/accesses.md
@@ -128,7 +128,7 @@ To get a single access use accessId as key. The single access contains details a
  
 Request
 ```http
-GET /onapi/2.4/accesses/STTA0001 HTTP/1.1
+GET /onapi/2.4/accesses/{accessId} HTTP/1.1
 ```
 
 Response 

--- a/2.4.0/spec/invoice_specification.md
+++ b/2.4.0/spec/invoice_specification.md
@@ -47,7 +47,7 @@ Content-Type: application/json
 A GET operation with a id from the previous list operation as key fetches the specification that invoice.
 
 ```HTTP
-GET /onapi/2.4/invoicespecification/201901 HTTP/1.1
+GET /onapi/2.4/invoicespecification/{id} HTTP/1.1
 ```
 
 Response

--- a/2.4.0/spec/orderevents.md
+++ b/2.4.0/spec/orderevents.md
@@ -38,7 +38,7 @@ To get events the last event ID in the previous fetch is used as a parameter to 
 
 Request:
 ```http
-GET /onapi/2.4/orderevents/?since=2a6d6432e59d11e39a523c970e806452 HTTP/1.1
+GET /onapi/2.4/orderevents/?since={event} HTTP/1.1
 ```
 
 Response:

--- a/2.4.0/spec/orders.md
+++ b/2.4.0/spec/orders.md
@@ -161,7 +161,7 @@ Content-Type: application/json
 Request
 
 ```HTTP
-GET /onapi/2.4/orders/f3f26446f6e8407aae876ea8e52d7417 HTTP/1.1
+GET /onapi/2.4/orders/{orderId} HTTP/1.1
 ```
 
 Response
@@ -442,7 +442,7 @@ With put it is possible to update an order for which the state is "RECEIVED", us
 Request
 
 ```HTTP
-PUT /onapi/2.4/orders/f3f26446f6e8407aae876ea8e52d7417 HTTP/1.1
+PUT /onapi/2.4/orders/{orderId} HTTP/1.1
 Content-Type: application/json
 ```
 
@@ -480,7 +480,7 @@ With patch it is possible to update an order for which the state is "RECEIVED", 
 Request
 
 ```HTTP
-PATCH /onapi/2.4/orders/f3f26446f6e8407aae876ea8e52d7417 HTTP/1.1
+PATCH /onapi/2.4/orders/{orderId} HTTP/1.1
 Content-Type: application/json
 ```
 

--- a/2.5.0/spec/accesses.md
+++ b/2.5.0/spec/accesses.md
@@ -128,7 +128,7 @@ To get a single access use accessId as key. The single access contains details a
  
 Request
 ```http
-GET /onapi/2.5/accesses/STTA0001 HTTP/1.1
+GET /onapi/2.5/accesses/{accessId} HTTP/1.1
 ```
 
 Response 

--- a/2.5.0/spec/invoice_specification.md
+++ b/2.5.0/spec/invoice_specification.md
@@ -47,7 +47,7 @@ Content-Type: application/json
 A GET operation with a id from the previous list operation as key fetches the specification that invoice.
 
 ```HTTP
-GET /onapi/2.5/invoicespecification/201901 HTTP/1.1
+GET /onapi/2.5/invoicespecification/{id} HTTP/1.1
 ```
 
 Response

--- a/2.5.0/spec/orderevents.md
+++ b/2.5.0/spec/orderevents.md
@@ -38,7 +38,7 @@ To get events the last event ID in the previous fetch is used as a parameter to 
 
 Request:
 ```http
-GET /onapi/2.5/orderevents/?since=2a6d6432e59d11e39a523c970e806452 HTTP/1.1
+GET /onapi/2.5/orderevents/?since={event} HTTP/1.1
 ```
 
 Response:

--- a/2.5.0/spec/orders.md
+++ b/2.5.0/spec/orders.md
@@ -164,7 +164,7 @@ Content-Type: application/json
 Request
 
 ```HTTP
-GET /onapi/2.5/orders/f3f26446f6e8407aae876ea8e52d7417 HTTP/1.1
+GET /onapi/2.5/orders/{orderId} HTTP/1.1
 ```
 
 Response
@@ -475,7 +475,7 @@ With put it is possible to update an order for which the state is "RECEIVED", us
 Request
 
 ```HTTP
-PUT /onapi/2.5/orders/f3f26446f6e8407aae876ea8e52d7417 HTTP/1.1
+PUT /onapi/2.5/orders/{orderId} HTTP/1.1
 Content-Type: application/json
 ```
 
@@ -521,7 +521,7 @@ With patch it is possible to update an order for which the state is "RECEIVED", 
 Request
 
 ```HTTP
-PATCH /onapi/2.5/orders/f3f26446f6e8407aae876ea8e52d7417 HTTP/1.1
+PATCH /onapi/2.5/orders/{orderId} HTTP/1.1
 Content-Type: application/json
 ```
 
@@ -692,4 +692,3 @@ Can be used in the response to describe why the status is DONE_FAILED
 
 * Data format: [text](../common/dataformats.md#text)
 * Required (but may be empty)
- 


### PR DESCRIPTION
Fixes https://github.com/on-api/on-api/issues/82